### PR TITLE
Various Improvements

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,15 @@
+# Get current datetime
+export DATE=$(date)
+
+# fly.io app name
+# https://fly.io/docs/reference/configuration/#the-app-name
+export APP_NAME=""
+# fly.io app region
+# https://fly.io/docs/reference/regions/#fly-io-regions
+# List regions with: flyctl platform regions
+export PRIMARY_REGION=""
+
+# Backblaze B2 bucket name used by litestream
+export LITESTREAM_REPLICA_BUCKET=""
+# Backblaze B2 endpoint used by litestream
+export LITESTREAM_REPLICA_ENDPOINT=""

--- a/.env.sample
+++ b/.env.sample
@@ -9,7 +9,7 @@ export APP_NAME=""
 # List regions with: flyctl platform regions
 export PRIMARY_REGION=""
 
-# Backblaze B2 bucket name used by litestream
+# Backblaze B2 bucket name used by litestream - from prerequisite section
 export LITESTREAM_REPLICA_BUCKET=""
-# Backblaze B2 endpoint used by litestream
+# Backblaze B2 endpoint used by litestream - from prerequisite section
 export LITESTREAM_REPLICA_ENDPOINT=""

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-fly.toml
+/fly.toml

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /fly.toml
+/.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-# Declare args
 ARG ALPINE_IMAGE_TAG=3.14
 ARG LINKDING_IMAGE_TAG=latest
-ARG LITESTREAM_VERSION=v0.3.8
 
 FROM docker.io/alpine:$ALPINE_IMAGE_TAG as builder
 
+ARG LITESTREAM_VERSION=v0.3.8
 # Download the static build of Litestream directly into the path & make it executable.
 # This is done in the builder and copied as the chmod doubles the size.
 ADD https://github.com/benbjohnson/litestream/releases/download/$LITESTREAM_VERSION/litestream-$LITESTREAM_VERSION-linux-amd64-static.tar.gz /tmp/litestream.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
-FROM alpine:3.14 as builder
+# Declare args
+ARG ALPINE_IMAGE_TAG=3.14
+ARG LINKDING_IMAGE_TAG=latest
+ARG LITESTREAM_VERSION=v0.3.8
+
+FROM docker.io/alpine:$ALPINE_IMAGE_TAG as builder
 
 # Download the static build of Litestream directly into the path & make it executable.
 # This is done in the builder and copied as the chmod doubles the size.
-ADD https://github.com/benbjohnson/litestream/releases/download/v0.3.8/litestream-v0.3.8-linux-amd64-static.tar.gz /tmp/litestream.tar.gz
+ADD https://github.com/benbjohnson/litestream/releases/download/$LITESTREAM_VERSION/litestream-$LITESTREAM_VERSION-linux-amd64-static.tar.gz /tmp/litestream.tar.gz
 RUN tar -C /usr/local/bin -xzf /tmp/litestream.tar.gz
 
-# Pull in latest linkding docker image.
-FROM sissbruecker/linkding:latest
+# Pull linkding docker image.
+FROM docker.io/sissbruecker/linkding:$LINKDING_IMAGE_TAG
 
 # Copy Litestream from builder.
 COPY --from=builder /usr/local/bin/litestream /usr/local/bin/litestream

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Felix Spöttel
+Copyright (c) 2023 Felix Spöttel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -137,9 +137,7 @@ Check the output of `flyctl doctor`, every line should be marked as **PASSED**. 
 
 #### Fly does not pull in the latest version of linkding
 
-Either:
-
-- Specify a version number in the [Dockerfile](https://github.com/fspoettel/linkding-on-fly/blob/master/Dockerfile#L9).
+- Override the [Dockerfile](Dockerfile#L2) build argument `LINKDING_IMAGE_TAG`: `flyctl deploy --build-arg LINKDING_IMAGE_TAG=<tag>`
 - Run `flyctl deploy` with the `--no-cache` option.
 
 #### Create a linkding superuser manually

--- a/README.md
+++ b/README.md
@@ -1,129 +1,114 @@
 # linkding on fly
 
-> 🔖 Run the self-hosted bookmark service [linkding](https://github.com/sissbruecker/linkding) on [fly.io](https://fly.io/). Automatically backup the bookmark database to [B2](https://www.backblaze.com/b2/cloud-storage.html) with [litestream](https://litestream.io/).
+> 🔖 Run the self-hosted bookmark service [linkding](https://github.com/sissbruecker/linkding) on [fly.io](https://fly.io/). Automatically backup the bookmark database to [Backblaze B2](https://www.backblaze.com/b2/cloud-storage.html) with [litestream](https://litestream.io/).
 
 ### Pricing
 
-Assuming one 256MB VM and a 3GB volume, this setup fits within Fly's free tier. [^0] Backups with B2 are free as well. [^1]
+Assuming one 256MB VM and a 3GB volume, this setup fits within Fly's free tier. [^0] Backups with Backblaze B2 are free as well. [^1]
 
-[^0]: otherwise the VM is ~$2 per month. $0.15/GB per month for the persistent volume.
-[^1]: the first 10GB are free, then $0.005 per GB.
+[^0]: Otherwise the VM is ~$2 per month. $0.15/GB per month for the persistent volume.
+[^1]: The first 10GB are free, then $0.005 per GB.
 
 ### Prerequisites
 
- - a [fly.io](https://fly.io/) account
- - a [backblaze](https://www.backblaze.com/) account
- - a clone of this repository
+- A [fly.io](https://fly.io/) account
+- A [Backblaze](https://www.backblaze.com/) account
+- `flyctl` CLI installed. [^2]
 
-All commands should be run in the directory of your local clone of this repository.
+[^2]: https://fly.io/docs/getting-started/installing-flyctl/
 
-### Install flyctl
+#### Litestream - Create Backblaze B2 Bucket and Application Key
 
-Follow [the instructions](https://fly.io/docs/getting-started/installing-flyctl/) to install fly's command-line interface `flyctl`.
+> ℹ️ If you want to use another storage provider, check litestream's ["Replica Guides"](https://litestream.io/guides/#replica-guides) section and adjust the config as needed.
 
-Then, [log into flyctl](https://fly.io/docs/getting-started/log-in-to-fly/).
+Log into [Backblaze B2](https://secure.backblaze.com/user_signin.htm) and [create a bucket](https://litestream.io/guides/backblaze/#create-a-bucket). Once created, you will see the bucket's name and endpoint. You will use these later to populate `LITESTREAM_REPLICA_BUCKET` and `LITESTREAM_REPLICA_ENDPOINT` in the `.env` file.
 
-```sh
-flyctl auth login
-```
-
-### Launch a fly application
-
-Launch the fly application. When asked, **do not** setup Postgres and **do not** deploy yet.
-
-```sh
-flyctl launch
-```
-
-This command creates a `fly.toml` file. Open it and add an `env` section.
-
-```toml
-[env]
-  # linkding's internal port, should be 8080 on fly.
-  LD_SERVER_PORT="8080"
-  # Path to linkding's sqlite database.
-  DB_PATH="/etc/linkding/data/db.sqlite3"
-  # B2 replica path.
-  LITESTREAM_REPLICA_PATH="linkding_replica.sqlite3"
-  # B2 endpoint.
-  LITESTREAM_REPLICA_ENDPOINT="<filled_later>"
-  # B2 bucket name.
-  LITESTREAM_REPLICA_BUCKET="<filled_later>"
-```
-
-### Add a persistent volume
-
-Create a [persistent volume](https://fly.io/docs/reference/volumes/). Fly's free tier includes `3GB` of storage across your VMs. Since `linkding` is very light on storage, a `1GB` volume will be more than enough for most use cases. It's possible to change volume size later. A how-to can be found in the _"scale persistent volume"_ section below.
-
-```sh
-flyctl volumes create linkding_data --region <your_region> --size <size_in_gb>
-```
-
-Attach the persistent volume to the container by adding a `mounts` section to `fly.toml`.
-
-```toml
-[mounts]
-  source="linkding_data"
-  destination="/etc/linkding/data"
-```
-
-### Configure litestream backups
-
-> ℹ️ If you want to use another storage provider, check litestream's ["Replica Guides"](https://litestream.io/guides/) section and adjust the config as needed.
-
-Log into B2 and [create a bucket](https://litestream.io/guides/backblaze/#create-a-bucket). Instead of adjusting the litestream config directly, we will add storage configuration to `fly.toml`. In the `env` section, set `LITESTREAM_REPLICA_ENDPOINT` and `LITESTREAM_REPLICA_BUCKET` to your newly created bucket's endpoint and name.
-
-Then, create [an access key](https://litestream.io/guides/backblaze/#create-a-user) for this bucket. Add the key to fly's secret store.
+Next, create [an application key](https://litestream.io/guides/backblaze/#create-a-user) for the bucket. Once created, you will see the `keyID` and `applicationKey` to add to Fly's secret store:
 
 ```sh
 flyctl secrets set LITESTREAM_ACCESS_KEY_ID="<keyId>" LITESTREAM_SECRET_ACCESS_KEY="<applicationKey>"
 ```
 
-### Create a linkding superuser
+### Usage
 
-You can create the linkding superuser prior to deployment by adding the following to fly's secret store:
+1. Clone the repository:
 
-```sh
-flyctl secrets set LD_SUPERUSER_NAME="<username>" LD_SUPERUSER_PASSWORD="<password>"
-```
+    ```sh
+    git clone https://github.com/fspoettel/linkding-on-fly.git && cd linkding-on-fly
+    ```
 
-### Deploy to fly
+2. Login to [`flyctl`](https://fly.io/docs/getting-started/log-in-to-fly/):
 
-Deploy the application to fly.
+    ```sh
+    flyctl auth login
+    ```
 
-```sh
-flyctl deploy
-```
+3. Create a [persistent volume](https://fly.io/docs/reference/volumes/) to store the `linkding` application data:
 
-If all is well, you can now access linkding by running `flyctl open`. You should see its login page.
+    > Fly's free tier includes `3GB` of storage across your VMs. Since `linkding` is very light on storage, a `1GB` volume will be more than enough for most use cases. It's possible to change volume size later. A how-to can be found in the _"Verify Backups / Scale Persistent Volume"_ section below.
 
-That's it! You can now log into your linkding installation and start using it.
+    ```sh
+    # List available regions via: flyctl platform regions
+    flyctl volumes create linkding_data --region <region code> --size 1
+    ```
+
+4. Add the `linkding` superuser credentials to fly's secret store:
+
+    ```sh
+    flyctl secrets set LD_SUPERUSER_NAME="<username>" LD_SUPERUSER_PASSWORD="<password>"
+    ```
+
+5. Copy the [.env.sample](.env.sample) file to `.env`, fill in the values and source them:
+
+    ```sh
+    cp .env.sample .env
+    # vim .env
+    source .env
+    ```
+
+6. Create the [`fly.toml`](https://fly.io/docs/reference/configuration/) from the [template](templates/fly.toml):
+
+    ```sh
+    envsubst < templates/fly.toml > fly.toml
+    ```
+
+7. Deploy `linkding` to fly:
+
+    > When asked, **do not** setup Postgres or Redis.
+
+    ```sh
+    flyctl deploy
+    ```
+
+If all goes well, you can now access `linkding` by running `flyctl open`. You should see the `linkding` login page.
+
+That's it! 🚀 You can now log into your `linkding` installation and start using it.
 
 If you wish, you can [configure a custom domain for your install](https://fly.io/docs/app-guides/custom-domains-with-fly/).
 
-### Verify the installation
+### Verify the Installation
 
- - you should be able to log into your linkding instance.
- - there should be an initial replica of your database in your B2 bucket.
- - your user data should survive a restart of the VM.
+- You should be able to log into your linkding instance.
+- There should be an initial replica of your database in your B2 bucket.
+- Your user data should survive a restart of the VM.
 
-### Verify backups / scale persistent volume
+### Verify Backups / Scale Persistent Volume
 
-Litestream continuously backs up your database by persisting its [WAL](https://en.wikipedia.org/wiki/Write-ahead_logging) to B2, once per second.
+Litestream continuously backs up your database by persisting its [WAL](https://en.wikipedia.org/wiki/Write-ahead_logging) to the Backblaze B2 bucket, once per second.
 
 There are two ways to verify these backups:
 
- 1. run the docker image locally or on a second VM. Verify the DB restores correctly.
- 2. swap the fly volume for a new one and verify the DB restores correctly.
+1. Run the docker image locally or on a second VM. Verify the DB restores correctly.
+2. Swap the fly volume for a new one and verify the DB restores correctly.
 
 We will focus on _2_ as it simulates an actual data loss scenario. This procedure can also be used to scale your volume to a different size.
 
 Start by making a manual backup of your data:
 
- 1. ssh into the VM and copy the DB to a remote. If only you are using your instance, you can also export bookmarks as HTML.
- 2. make a snapshot of the B2 bucket in the B2 admin panel.
+1. Ssh into the VM and copy the DB to a remote. If only you are using your instance, you can also export bookmarks as HTML.
+2. Make a snapshot of the B2 bucket in the B2 admin panel.
 
-Now list all fly volumes and note the id of the `linkding_data` volume. Then, delete the volume.
+Now list all fly volumes and note the id of the `linkding_data` volume. Then, delete the volume:
 
 ```sh
 flyctl volumes list
@@ -132,7 +117,7 @@ flyctl volumes delete <id>
 
 This will result in a **dead** VM after a few seconds. Create a new `linkding_data` volume. Your application should automatically attempt to restart. If not, restart it manually.
 
-When the application starts, you should see the successful restore in the logs.
+When the application starts, you should see the successful restore in the logs:
 
 ```
 [info] No database found, attempt to restore from a replica.
@@ -142,24 +127,24 @@ When the application starts, you should see the successful restore in the logs.
 
 ### Troubleshooting
 
-#### litestream is logging 403 errors
+#### Litestream is logging 403 errors
 
 Check that your B2 secrets and environment variables are correct.
 
-#### fly ssh does not connect
+#### Fly ssh does not connect
 
 Check the output of `flyctl doctor`, every line should be marked as **PASSED**. If `Pinging WireGuard` fails, try `flyctl wireguard reset` and `flyctl agent restart`.
 
-#### fly does not pull in the latest version of linkding
+#### Fly does not pull in the latest version of linkding
 
-either:
+Either:
 
- - specify a version number in the [Dockerfile](https://github.com/fspoettel/linkding-on-fly/blob/master/Dockerfile#L9)
- - run `flyctl deploy` with the `--no-cache` option
+- Specify a version number in the [Dockerfile](https://github.com/fspoettel/linkding-on-fly/blob/master/Dockerfile#L9).
+- Run `flyctl deploy` with the `--no-cache` option.
 
 #### Create a linkding superuser manually
 
-If you have never used fly's SSH console before, begin by setting up fly's ssh-agent.
+If you have never used fly's SSH console before, begin by setting up fly's ssh-agent:
 
 ```sh
 flyctl ssh establish

--- a/README.md
+++ b/README.md
@@ -58,21 +58,65 @@ flyctl secrets set LITESTREAM_ACCESS_KEY_ID="<keyId>" LITESTREAM_SECRET_ACCESS_K
     flyctl secrets set LD_SUPERUSER_NAME="<username>" LD_SUPERUSER_PASSWORD="<password>"
     ```
 
-5. Copy the [.env.sample](.env.sample) file to `.env`, fill in the values and source them:
+5. Create the [`fly.toml`](https://fly.io/docs/reference/configuration/):
 
-    ```sh
-    cp .env.sample .env
-    # vim .env
-    source .env
+    <details>
+    <summary>Generating from Template</summary>
+
+    You can generate the `fly.toml` from the [template](templates/fly.toml) provided in this repository.
+
+    1. Install [`envsubst`](https://www.gnu.org/software/gettext/manual/html_node/envsubst-Invocation.html) if you don't have it already:
+
+        ```sh
+        # macOS
+        brew install gettext
+        ```
+
+    2. Copy the [.env.sample](.env.sample) file to `.env`, fill in the values and source them:
+
+        ```sh
+        cp .env.sample .env
+        # vim .env
+        source .env
+        ```
+
+    3. Generate the `fly.toml` from the template:
+
+        ```sh
+        envsubst < templates/fly.toml > fly.toml
+        ```
+
+    4. Proceed to step 6.
+    </details>
+
+    > ℹ️ When asked, **do not** setup Postgres or Redis.
+
+    ```
+    # Generate the initial fly.toml
+    flyctl launch
     ```
 
-6. Create the [`fly.toml`](https://fly.io/docs/reference/configuration/) from the [template](templates/fly.toml):
+    Next, open the `fly.toml` and add the following `env` and `mounts` sections:
 
-    ```sh
-    envsubst < templates/fly.toml > fly.toml
+    ```
+    [env]
+      # linkding's internal port, should be 8080 on fly.
+      LD_SERVER_PORT="8080"
+      # Path to linkding's sqlite database.
+      DB_PATH="/etc/linkding/data/db.sqlite3"
+      # B2 replica path.
+      LITESTREAM_REPLICA_PATH="linkding_replica.sqlite3"
+      # B2 endpoint.
+      LITESTREAM_REPLICA_ENDPOINT="<filled_later>"
+      # B2 bucket name.
+      LITESTREAM_REPLICA_BUCKET="<filled_later>"
+
+    [mounts]
+      source="linkding_data"
+      destination="/etc/linkding/data"
     ```
 
-7. Deploy `linkding` to fly:
+6. Deploy `linkding` to fly:
 
     > ℹ️ When asked, **do not** setup Postgres or Redis.
     >

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ flyctl secrets set LITESTREAM_ACCESS_KEY_ID="<keyId>" LITESTREAM_SECRET_ACCESS_K
     flyctl launch
     ```
 
-    Next, open the `fly.toml` and add the following `env` and `mounts` sections:
+    Next, open the `fly.toml` and add the following `env` and `mounts` sections (populating `LITESTREAM_REPLICA_ENDPOINT` and `LITESTREAM_REPLICA_BUCKET`):
 
     ```
     [env]
@@ -107,9 +107,9 @@ flyctl secrets set LITESTREAM_ACCESS_KEY_ID="<keyId>" LITESTREAM_SECRET_ACCESS_K
       # B2 replica path.
       LITESTREAM_REPLICA_PATH="linkding_replica.sqlite3"
       # B2 endpoint.
-      LITESTREAM_REPLICA_ENDPOINT="<filled_later>"
+      LITESTREAM_REPLICA_ENDPOINT="<Backblaze B2 endpoint>"
       # B2 bucket name.
-      LITESTREAM_REPLICA_BUCKET="<filled_later>"
+      LITESTREAM_REPLICA_BUCKET="<Backblaze B2 bucket name>"
 
     [mounts]
       source="linkding_data"

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ flyctl secrets set LITESTREAM_ACCESS_KEY_ID="<keyId>" LITESTREAM_SECRET_ACCESS_K
 7. Deploy `linkding` to fly:
 
     > ℹ️ When asked, **do not** setup Postgres or Redis.
+    >
+    > ℹ️ The [Dockerfile](Dockerfile) contains overridable build arguments: `ALPINE_IMAGE_TAG`, `LINKDING_IMAGE_TAG` and `LITESTREAM_VERSION` which can overridden by passing them to `flyctl deploy` like `--build-arg LINKDING_IMAGE_TAG=v0.3.9` etc.
 
     ```sh
     flyctl deploy

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ flyctl secrets set LITESTREAM_ACCESS_KEY_ID="<keyId>" LITESTREAM_SECRET_ACCESS_K
 
 3. Create a [persistent volume](https://fly.io/docs/reference/volumes/) to store the `linkding` application data:
 
-    > Fly's free tier includes `3GB` of storage across your VMs. Since `linkding` is very light on storage, a `1GB` volume will be more than enough for most use cases. It's possible to change volume size later. A how-to can be found in the _"Verify Backups / Scale Persistent Volume"_ section below.
+    > ℹ️ Fly's free tier includes `3GB` of storage across your VMs. Since `linkding` is very light on storage, a `1GB` volume will be more than enough for most use cases. It's possible to change volume size later. A how-to can be found in the _"Verify Backups / Scale Persistent Volume"_ section below.
 
     ```sh
     # List available regions via: flyctl platform regions
@@ -74,15 +74,13 @@ flyctl secrets set LITESTREAM_ACCESS_KEY_ID="<keyId>" LITESTREAM_SECRET_ACCESS_K
 
 7. Deploy `linkding` to fly:
 
-    > When asked, **do not** setup Postgres or Redis.
+    > ℹ️ When asked, **do not** setup Postgres or Redis.
 
     ```sh
     flyctl deploy
     ```
 
-If all goes well, you can now access `linkding` by running `flyctl open`. You should see the `linkding` login page.
-
-That's it! 🚀 You can now log into your `linkding` installation and start using it.
+That's it! 🚀 - If all goes well, you can now access `linkding` by running `flyctl open`. You should see the `linkding` login page and be able to log in with the superuser credentials you set in step 4.
 
 If you wish, you can [configure a custom domain for your install](https://fly.io/docs/app-guides/custom-domains-with-fly/).
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ We will focus on _2_ as it simulates an actual data loss scenario. This procedur
 
 Start by making a manual backup of your data:
 
-1. Ssh into the VM and copy the DB to a remote. If only you are using your instance, you can also export bookmarks as HTML.
+1. SSH into the VM and copy the DB to a remote. If only you are using your instance, you can also export bookmarks as HTML.
 2. Make a snapshot of the B2 bucket in the B2 admin panel.
 
 Now list all fly volumes and note the id of the `linkding_data` volume. Then, delete the volume:

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ flyctl secrets set LITESTREAM_ACCESS_KEY_ID="<keyId>" LITESTREAM_SECRET_ACCESS_K
 
     Next, open the `fly.toml` and add the following `env` and `mounts` sections (populating `LITESTREAM_REPLICA_ENDPOINT` and `LITESTREAM_REPLICA_BUCKET`):
 
-    ```
+    ```toml
     [env]
       # linkding's internal port, should be 8080 on fly.
       LD_SERVER_PORT="8080"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Assuming one 256MB VM and a 3GB volume, this setup fits within Fly's free tier. 
 
 Log into [Backblaze B2](https://secure.backblaze.com/user_signin.htm) and [create a bucket](https://litestream.io/guides/backblaze/#create-a-bucket). Once created, you will see the bucket's name and endpoint. You will use these later to populate `LITESTREAM_REPLICA_BUCKET` and `LITESTREAM_REPLICA_ENDPOINT` in the `.env` file.
 
-Next, create [an application key](https://litestream.io/guides/backblaze/#create-a-user) for the bucket. Once created, you will see the `keyID` and `applicationKey` to add to Fly's secret store:
+Next, create [an application key](https://litestream.io/guides/backblaze/#create-a-user) for the bucket. Once created, you will see the `keyID` and `applicationKey`. Add these to Fly's secret store:
 
 ```sh
 flyctl secrets set LITESTREAM_ACCESS_KEY_ID="<keyId>" LITESTREAM_SECRET_ACCESS_KEY="<applicationKey>"

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ flyctl secrets set LITESTREAM_ACCESS_KEY_ID="<keyId>" LITESTREAM_SECRET_ACCESS_K
 
     > ℹ️ When asked, **do not** setup Postgres or Redis.
     >
-    > ℹ️ The [Dockerfile](Dockerfile) contains overridable build arguments: `ALPINE_IMAGE_TAG`, `LINKDING_IMAGE_TAG` and `LITESTREAM_VERSION` which can overridden by passing them to `flyctl deploy` like `--build-arg LINKDING_IMAGE_TAG=v0.3.9` etc.
+    > ℹ️ The [Dockerfile](Dockerfile) contains overridable build arguments: `ALPINE_IMAGE_TAG`, `LINKDING_IMAGE_TAG` and `LITESTREAM_VERSION` which can overridden by passing them to `flyctl deploy` like `--build-arg LITESTREAM_VERSION=v0.3.9` etc.
 
     ```sh
     flyctl deploy

--- a/templates/fly.toml
+++ b/templates/fly.toml
@@ -1,0 +1,27 @@
+# fly.toml app configuration file generated for ${APP_NAME} on ${DATE}
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = "${APP_NAME}"
+# https://fly.io/docs/reference/regions/#fly-io-regions
+primary_region = "${PRIMARY_REGION}"
+
+[env]
+  DB_PATH = "/etc/linkding/data/db.sqlite3"
+  LD_SERVER_PORT = "8080"
+  LITESTREAM_REPLICA_PATH = "linkding_replica.sqlite3"
+  # Backblaze B2 bucket name
+  LITESTREAM_REPLICA_BUCKET = "${LITESTREAM_REPLICA_BUCKET}"
+  # Backblaze B2 bucket endpoint
+  LITESTREAM_REPLICA_ENDPOINT = "${LITESTREAM_REPLICA_ENDPOINT}"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+
+[mounts]
+  source="linkding_data"
+  destination="/etc/linkding/data"


### PR DESCRIPTION
Hi @fspoettel 

Another PR 😃 - Quite a few changes in this one. I've tried to streamline the instructions into numbered steps. To make it as simple as possible. Also, using some native commands to pre-populate a template `fly.toml` to reduce copy pasting.

Also, made creating the backup and credentials a prerequisite step so the usage is a smoother process.

https://github.com/dbrennand/linkding-on-fly/tree/refactor/template-buildargs

## Summary

- Added `ARG` statements to the Dockerfile to easily override image tags and litestream version. Default values are set to be as they are currently.
- Documented overriding `ARG` in the Dockerfile when using `flyctl deploy`
- Improved some grammar in the README and restructured usage to reduce copy and pasting.
- Using a template `fly.toml` file to reduce copy pasting.
- To populate values in the aforementioned template, use a `.env` file to populate variables in the template and use common CLI `envsubst` to do this.
- Restructured README usage to numbered step by step instructions.