### PR TITLE
chore: update LITESTREAM_VERSION and small reordering in README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ ARG LINKDING_IMAGE_TAG=latest
 
 FROM docker.io/alpine:$ALPINE_IMAGE_TAG as builder
 
-ARG LITESTREAM_VERSION=v0.3.8
+ARG LITESTREAM_VERSION=v0.3.11
 # Download the static build of Litestream directly into the path & make it executable.
 # This is done in the builder and copied as the chmod doubles the size.
-ADD https://github.com/benbjohnson/litestream/releases/download/$LITESTREAM_VERSION/litestream-$LITESTREAM_VERSION-linux-amd64-static.tar.gz /tmp/litestream.tar.gz
+ADD https://github.com/benbjohnson/litestream/releases/download/$LITESTREAM_VERSION/litestream-$LITESTREAM_VERSION-linux-amd64.tar.gz /tmp/litestream.tar.gz
 RUN tar -C /usr/local/bin -xzf /tmp/litestream.tar.gz
 
 # Pull linkding docker image.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Next, create [an application key](https://litestream.io/guides/backblaze/#create
     > The [Dockerfile](Dockerfile) contains overridable build arguments: `ALPINE_IMAGE_TAG`, `LINKDING_IMAGE_TAG` and `LITESTREAM_VERSION` which can overridden by passing them to `flyctl deploy` like `--build-arg LITESTREAM_VERSION=v0.3.11` etc.
 
     
-That's it! 🚀 - If all goes well, you can now access `linkding` by running `flyctl open`. You should see the `linkding` login page and be able to log in with the superuser credentials you set in step 4.
+That's it! 🚀 - If all goes well, you can now access `linkding` by running `flyctl open`. You should see the `linkding` login page and be able to log in with the superuser credentials you set in step 5.
 
 If you wish, you can [configure a custom domain for your install](https://fly.io/docs/app-guides/custom-domains-with-fly/).
 


### PR DESCRIPTION
- update LITESTREAM_VERSION, static is now default
- small reordering in README because `flyctl volumes` and `flyctl volumes` need a fly app