### PR TITLE
Update uswgi.ini file to specify an extra static path for favicons

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -3,6 +3,7 @@ chdir = /etc/linkding
 module = siteroot.wsgi:application
 env = DJANGO_SETTINGS_MODULE=siteroot.settings.prod
 static-map = /static=static
+static-map = /static=data/favicons
 processes = 1
 threads = 2
 pidfile = /tmp/linkding.pid


### PR DESCRIPTION
Without this addition, favicons don't show when viewing the list of bookmarks. New line copied from the uwsgi.ini file in the main linkdings repo (https://github.com/sissbruecker/linkding/blob/0975914a8608268abc0f8ed4a90dfa6983de079d/uwsgi.ini#L5) which was added ~8 months ago in this commit (https://github.com/sissbruecker/linkding/commit/814401be2eb221982bfcd21a7be253d5f17a1b4a).