### PR TITLE
Create .gitattributes for line ending conversion to LF (Unix)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Hi @fspoettel,
I've brought a small suggestion as a contribution to your project, hope you like the idea!

If the user's `.gitconfig` has `core.autocrlf=true`, when cloning the repository, the files will have CRLF line endings. This leads to two issues that can be fixed manually but can be avoided with the suggested `.gitattributes` file here.
> ![git config](https://github.com/fspoettel/linkding-on-fly/assets/46982925/482f5277-0d5f-4fed-a775-6a97d4a52084)

1. **Bad formatting of the fly.toml from the template**
If the `.env.sample` file has CRLF, our `.env` file will also have CRLF automatically, causing a bad formatting of the `fly.toml`.
> ![source .env](https://github.com/fspoettel/linkding-on-fly/assets/46982925/07277ea9-3f97-4fb8-aa04-a87fb79f417f)

After execute `envsubst < templates/fly.toml > fly.toml` and verify with `nano fly.toml`
> ![fly.toml](https://github.com/fspoettel/linkding-on-fly/assets/46982925/9f8476e2-2f92-439c-8f83-40301d8cd0a7)


2. **Error running scripts/run.sh**
If the `scripts/run.sh` file has CRLF, it will be copied to the container that way and won't be able to run.
> ![logs](https://github.com/fspoettel/linkding-on-fly/assets/46982925/b97d1f53-0f6a-440a-a738-0d600472df74)


For now, thats's it. The project is amazing, thanks for sharing it with us!