### PR TITLE
Update WSGI module

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,7 +1,7 @@
 [uwsgi]
 chdir = /etc/linkding
-module = siteroot.wsgi:application
-env = DJANGO_SETTINGS_MODULE=siteroot.settings.prod
+module = bookmarks.wsgi:application
+env = DJANGO_SETTINGS_MODULE=bookmarks.settings.prod
 static-map = /static=static
 static-map = /static=data/favicons
 processes = 1


### PR DESCRIPTION
https://github.com/sissbruecker/linkding/commit/2d3bd13a12fd826465d5286f132bb48d8c531676 removes `siteroot` and moves everything from there under `bookmarks`.

Once that change is released (should be 1.40.0), the custom UWSGI config here needs to be updated.